### PR TITLE
Add consumer.update and fix stream.update

### DIFF
--- a/nats/aio/js/api/consumer.py
+++ b/nats/aio/js/api/consumer.py
@@ -115,6 +115,7 @@ class ConsumerAPI:
         self,
         stream: str,
         name: Optional[str] = None,
+        description: Optional[str] = None,
         deliver_subject: Optional[str] = None,
         deliver_group: Optional[str] = None,
         deliver_policy: DeliverPolicy = DeliverPolicy.last,
@@ -129,6 +130,9 @@ class ConsumerAPI:
         idle_heartbeat: Optional[int] = None,
         flow_control: Optional[bool] = None,
         max_waiting: Optional[int] = None,
+        ops_start_seq: Optional[int] = None,
+        ops_start_time: Optional[int] = None,
+        headers_only: Optional[bool] = None,
         timeout: float = 1,
     ) -> ConsumerCreateResponse:
         """Create a new consumer.
@@ -152,6 +156,7 @@ class ConsumerAPI:
         """
         config = dict(
             durable_name=name,
+            description=description,
             deliver_subject=deliver_subject,
             deliver_group=deliver_group,
             deliver_policy=deliver_policy,
@@ -166,6 +171,9 @@ class ConsumerAPI:
             idle_heartbeat=idle_heartbeat,
             flow_control=flow_control,
             max_waiting=max_waiting,
+            ops_start_time=ops_start_time,
+            ops_start_seq=ops_start_seq,
+            headers_only=headers_only,
         )
         subject = f"CONSUMER.DURABLE.CREATE.{stream}.{name}" if name else f"CONSUMER.CREATE.{stream}"
         return await self._js._request(
@@ -173,6 +181,48 @@ class ConsumerAPI:
             {
                 "stream_name": stream,
                 "config": config
+            },
+            timeout=timeout,
+            request_dc=ConsumerCreateRequest,
+            response_dc=ConsumerCreateResponse,
+        )
+
+    async def update(
+        self,
+        stream: str,
+        name: str,
+        description: Optional[str] = ...,  # type: ignore[assignment]
+        deliver_subject: Optional[str] = ...,  # type: ignore[assignment]
+        ack_wait: Optional[int] = ...,  # type: ignore[assignment]
+        max_deliver: int = ...,  # type: ignore[assignment]
+        sample_freq: Optional[str] = ...,  # type: ignore[assignment]
+        rate_limit_bps: Optional[int] = ...,  # type: ignore[assignment]
+        max_ack_pending: Optional[int] = ...,  # type: ignore[assignment]
+        max_waiting: Optional[int] = ...,  # type: ignore[assignment]
+        headers_only: Optional[bool] = ...,  # type: ignore[assignment]
+        timeout: float = 1,
+    ) -> ConsumerCreateResponse:
+        subject = f"CONSUMER.DURABLE.CREATE.{stream}.{name}"
+        config = dict(
+            durable_name=name,
+            description=description,
+            deliver_subject=deliver_subject,
+            ack_wait=ack_wait,
+            max_deliver=max_deliver,
+            sample_freq=sample_freq,
+            rate_limit_bps=rate_limit_bps,
+            max_ack_pending=max_ack_pending,
+            max_waiting=max_waiting,
+            headers_only=headers_only,
+        )
+        return await self._js._request(
+            subject,
+            {
+                "stream_name": stream,
+                "config": {
+                    key: value
+                    for key, value in config.items() if value is not ...
+                }
             },
             timeout=timeout,
             request_dc=ConsumerCreateRequest,

--- a/nats/aio/js/api/stream.py
+++ b/nats/aio/js/api/stream.py
@@ -194,14 +194,14 @@ class StreamAPI:
     async def update(
         self,
         name: str,
-        description: Optional[str] = None,
-        subjects: Optional[List[str]] = None,
-        discard: Optional[Discard] = None,
-        max_msgs: Optional[int] = None,
-        max_msgs_per_subject: Optional[int] = None,
-        max_bytes: Optional[int] = None,
-        max_age: Optional[int] = None,
-        num_replicas: Optional[int] = None,
+        description: Optional[str] = ...,  # type: ignore[assignment]
+        subjects: Optional[List[str]] = ...,  # type: ignore[assignment]
+        discard: Optional[Discard] = ...,  # type: ignore[assignment]
+        max_msgs: Optional[int] = ...,  # type: ignore[assignment]
+        max_msgs_per_subject: Optional[int] = ...,  # type: ignore[assignment]
+        max_bytes: Optional[int] = ...,  # type: ignore[assignment]
+        max_age: Optional[int] = ...,  # type: ignore[assignment]
+        num_replicas: Optional[int] = ...,  # type: ignore[assignment]
         timeout: float = 1,
         **kwargs: Any,
     ) -> StreamInfoResponse:
@@ -234,27 +234,27 @@ class StreamAPI:
         current_config = (await self.info(name, False)).config
         new_config: Dict[str, Any] = {}
         new_config["name"] = name
-        if description is not None:
+        if description is not ...:
             new_config["description"] = description
-        if subjects is not None:
+        if subjects is not ...:
             new_config["subjects"] = subjects
-        if discard is not None:
+        if discard is not ...:
             new_config["discard"] = discard
-        elif current_config.discard is not None:
+        elif current_config.discard is not ...:
             kwargs.pop("discard", None)
-            try:
-                new_config["discard"] = current_config.discard.value
-            except AttributeError:
+            if current_config.discard:
                 new_config["discard"] = current_config.discard
-        if max_msgs is not None:
+            else:
+                new_config["discard"] = current_config.discard
+        if max_msgs is not ...:
             new_config["max_msgs"] = max_msgs
-        if max_msgs_per_subject is not None:
+        if max_msgs_per_subject is not ...:
             new_config["max_msgs_per_subject"] = max_msgs_per_subject
-        if max_bytes is not None:
+        if max_bytes is not ...:
             new_config["max_bytes"] = max_bytes
-        if max_age is not None:
+        if max_age is not ...:
             new_config["max_age"] = max_age
-        if num_replicas is not None:
+        if num_replicas is not ...:
             new_config["num_replicas"] = num_replicas
         options = asdict(
             StreamUpdateRequest(
@@ -267,10 +267,8 @@ class StreamAPI:
         )
         return await self._js._request(
             f"STREAM.UPDATE.{name}",
-            {
-                key: value
-                for key, value in options.items() if value is not None
-            },
+            {key: value
+             for key, value in options.items() if value is not ...},
             timeout=timeout,
             response_dc=StreamInfoResponse,
         )

--- a/nats/aio/js/models/consumers.py
+++ b/nats/aio/js/models/consumers.py
@@ -82,6 +82,7 @@ class ConsumerConfig:
     deliver_group: Optional[str] = None
     ack_policy: AckPolicy = AckPolicy.explicit
     durable_name: Optional[str] = None
+    description: Optional[str] = None
     deliver_subject: Optional[str] = None
     ack_wait: Optional[int] = None
     max_deliver: Optional[int] = None
@@ -92,7 +93,7 @@ class ConsumerConfig:
     max_ack_pending: Optional[int] = None
     idle_heartbeat: Optional[int] = None
     flow_control: Optional[bool] = None
-    max_waiting: Optional[int] = 512
+    max_waiting: Optional[int] = None
     ops_start_seq: Optional[int] = None
     ops_start_time: Optional[int] = None
     headers_only: Optional[bool] = None

--- a/tests/test_client_v2.py
+++ b/tests/test_client_v2.py
@@ -426,6 +426,25 @@ class JetStreamTest(SingleJetStreamServerTestCase):
         await nc.close()
 
     @async_test
+    async def test_consumer_update_description(self):
+        nc = await nats.connect()
+        js = nc.jetstream()
+        await js.stream.add("TEST", subjects=["foo", "bar"])
+        create_response = await js.consumer.add(
+            "TEST", "foo", description="test consumer", deliver_subject=None
+        )
+        self.assertEqual(create_response.config.description, "test consumer")
+        update_response = await js.consumer.update(
+            "TEST", "foo", description="A test consumer"
+        )
+        info_response = await js.consumer.info("TEST", "foo")
+        self.assertEqual(
+            info_response.config.description,
+            update_response.config.description
+        )
+        await nc.close()
+
+    @async_test
     async def test_kv_create(self):
         nc = await nats.connect()
 


### PR DESCRIPTION
Latest nats-server release introduced the consumer API. This PR add the `js.consumer.update(...)` method.

It also changes the behaviour of `js.stream.update` to that `None` value can be used as a new value. Before this commit, the default value for keyword argument was `None`. As such it was not possible to distinguish a default value from a value explicitely set to `None` by user. Default value is now `...`.